### PR TITLE
Aschreiber1 revert sqlalchemy dep upgrade

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - pyiceberg = pyiceberg.cli.console:run
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,7 +66,7 @@ requirements:
     - adlfs >=2023.1.0,<2024.8.0
     - gcsfs >=2023.1.0,<2024.1.0
     - psycopg2-binary >=2.9.6
-    - sqlalchemy >=2.0.18,<3.0.0
+    - sqlalchemy >=1.4.0,<3.0.0
     - getdaft >=0.2.12
     - numpy >=1.22.4
 


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Sqlalchemy >= 2.0 breaks pandas < 2.0, given that it is defined in the package dependencies that we are trying to support pandas < 2.0, we need to keep support for Sqlalchemy < 2. 
Also sqlalchemy is only needed by pyiceberg for sql-lite and postgress dependencies, and not the usual use cases, so it's probably better to allow pyiceberg to be used in projects that need pandas < 2, and make the dependency process a little more error prone for people using it with postgres or sql lite, rather than the other way as it currently is